### PR TITLE
OpenBSD 7.2+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ import sys
 if sys.platform == 'linux':
     import glob
     from setuptools import setup
+elif sys.platform == 'openbsd7':
+	import glob
+	from setuptools import setup
 else:
     from cx_Freeze import setup, Executable
 


### PR DESCRIPTION
Please also add this to the Wiki:

# OpenBSD

```
pkg_add py3 py3-pip py3-qt5 py3-setuptools
pip3 install cx_freeze
pip3 install glob2
```
Make sure that the following is in setup.py:

[el]if sys.platform == 'openbsd7':
	import glob
	from setuptools import setup

`doas python3 setup.py install`

/usr/local/bin/qnotero
